### PR TITLE
here() in user_run_SDM, folder structure in _data

### DIFF
--- a/3_createModel.R
+++ b/3_createModel.R
@@ -570,9 +570,9 @@ save(list = ls.save, file = paste0("rdata/", model_run_name,".Rdata"), envir = e
 
 # write model metadata to db
 db <- dbConnect(SQLite(),dbname=nm_db_file)  
-insert_values <- paste(model_run_name, model_species, baseName, model_start_time, modeller, model_comp_name, r_version, model_comments, sep = "','")
+insert_values <- paste(dbQuoteString(db, c(model_run_name, model_species, baseName, model_start_time, modeller, model_comp_name, r_version, model_comments)), collapse = ",")
 SQLquery <- paste0("INSERT INTO tblModelRuns (modelRunName, CODE, tableCode, modelBeginTime, modeller, modelCompName, rVersion, internalComments)
-  VALUES ('",insert_values,"');")
+  VALUES (",insert_values,");")
 dbExecute(db, SQLquery)
 # write variable info to db
 varImpDB <- data.frame(modelRunName = model_run_name, gridName = envvar_list, inFinalModel = 0)

--- a/_data/env_vars/.gitignore
+++ b/_data/env_vars/.gitignore
@@ -1,0 +1,9 @@
+# ignore all files except .gitignore
+# but apply this file here to keep folder structure
+
+*
+
+!.gitignore
+!background
+!raster
+!tabular

--- a/_data/env_vars/background/.gitignore
+++ b/_data/env_vars/background/.gitignore
@@ -1,0 +1,6 @@
+# ignore all files except .gitignore
+# but apply this file here to keep folder structure
+
+*
+
+!.gitignore

--- a/_data/env_vars/raster/.gitignore
+++ b/_data/env_vars/raster/.gitignore
@@ -1,0 +1,6 @@
+# ignore all files except .gitignore
+# but apply this file here to keep folder structure
+
+*
+
+!.gitignore

--- a/_data/env_vars/tabular/.gitignore
+++ b/_data/env_vars/tabular/.gitignore
@@ -1,0 +1,6 @@
+# ignore all files except .gitignore
+# but apply this file here to keep folder structure
+
+*
+
+!.gitignore

--- a/_data/occurrence/.gitignore
+++ b/_data/occurrence/.gitignore
@@ -1,0 +1,6 @@
+# ignore all files except .gitignore
+# but apply this file here to keep folder structure
+
+*
+
+!.gitignore

--- a/_data/other_spatial/.gitignore
+++ b/_data/other_spatial/.gitignore
@@ -1,0 +1,6 @@
+# ignore all files except .gitignore
+# but apply this file here to keep folder structure
+
+*
+
+!.gitignore

--- a/user_run_SDM.R
+++ b/user_run_SDM.R
@@ -2,42 +2,47 @@
 # Purpose: Run a full SDM model, or pickup an existing run executed using run_SDM.
 # After running a full model, save this file in the species' 'loc_scripts' folder
 
-# Step 1: Download updated scripts from GitHub repository
-# Usage: to put the latest modeling scripts in a new folder created in 'loc_scripts' (set below),
-# which are used for new modeling runs
-
-# set project folder, db, species code, and species reaches filename for this run
+library(here)
 rm(list=ls())
-# The main modelling folder for inputs/outputs. All sub-folders are created during the model run (when starting with step 1)
-loc_model <- "E:/git/dnbucklin/Regional_SDM/_data/species"
-# Modeling database
-nm_db_file <- "E:/git/dnbucklin/Regional_SDM/_data/databases/sdm_tracking_dev_all.sqlite"
-# species code (from lkpSpecies in modelling database. This will be the new folder name in loc_model.)
+
+# Step 1: Setting for the model run
+# set project folder, db, species code, and species reaches filename for this run
+
+# species code (from lkpSpecies in modelling database. This will be the new folder name containing inputs/ouptuts)
 model_species <- "micrmont"
+# loc_scripts is your repository. Make sure your git repository is set to correct branch
+loc_scripts <- here()
+# The main modelling folder for inputs/outputs. All sub-folders are created during the model run (when starting with step 1)
+loc_model <- here("_data", "species")
+# Modeling database
+nm_db_file <- here("_data", "databases", "sdm_tracking_dev_all.sqlite")
 # locations file (presence reaches). Provide full path; File is copied to modeling folder and timestamped.
-nm_presFile <- "D:/SDM/Tobacco/inputs/species/micrmont/polygon_data/micrmont.shp"
+nm_presFile <- here("_data", "occurrence", model_species)
+# env vars location [Terrestrial-only variable]
+loc_envVars = here("_data","env_vars","raster")
+# bkg points [Terrestrial-only variable]
+nm_bkgPts = here("_data","env_vars","background","tobacco_att.shp")
+# map reference boundaries
+nm_refBoundaries = here("_data","other_spatial","feature","StatesEast.shp") # background grey refernce lines in map
+# map project boundary
+nm_studyAreaExtent = here("_data","other_spatial","feature","sdmVA_pred_20170131.shp") # outline black boundary line for study area in map
+# model comment in database
+model_comments = "testing master"
+# comment printed in PDF metadata
+metaData_comments = "bla bla"
+# your name
+modeller = "David Bucklin"
 
-### USE THIS SECTION IS IF YOU WANT A NEW SCRIPT REPO FOR THIS RUN
-## this downloads latest scripts from GitHub (you can save this 'get_scripts.R' 
-## file anywhere on your computer, so you don't have to change the path)
-## github branch to download
-
-# branch <- "master"
-# source("E:/git/dnbucklin/Regional_SDM/helper/get_scripts.R", local = TRUE)
-
-### NOTE any messages, and download/place scripts manually if necessary
-######
-######
-
-### OTHERWISE, for testing, or if get_scripts failed, just set loc_scripts below
-loc_scripts <- "E:/git/dnbucklin/Regional_SDM/"
-
-# remove everything but necessary variables
-rm(list = ls(all.names = TRUE)[!ls(all.names = TRUE) %in% c("nm_db_file","model_species","loc_scripts", "loc_model", "nm_presFile")])
+# list non-standard variables to "add" to model run
+add_vars = NULL
+# list standard variables to remove from model run
+remove_vars = NULL
+# do you want to stop execution after each modeling step (script)?
+prompt = TRUE
 
 # set wd and load function
 setwd(loc_scripts)
-source("helper/run_SDM.R")
+source(here("helper", "run_SDM.R"))
 
 ##############
 # End step 1 #
@@ -45,20 +50,10 @@ source("helper/run_SDM.R")
 
 # Step 2: execute a new model
 # Usage: For a full, new model run, provide all paths/file names to arguments 'loc_scripts' THROUGH 'modeller'.
-
-# Optional arguments for all runs include:
-# 1. begin_step: specify as the prefix of the step to begin with: one of ("1","2","3","4","4b","4c","5").
-#     Defaults to "1", so not necessary to specify for new runs.
-# 2. prompt: if TRUE, the function will stop after each script, and ask if you want to continue. 
-#     Defaults to FALSE.
-# 3. add_vars: variables that are not part of the standard set for this species, which you wish to 
-#     include in the model run.
-# 4. remove_vars: variables that are part of the standard set for this species, which you wish to
-#     remove from the model run.
-
 # RUN A NEW MODEL (ALL STEPS 1-5)
 # If picking up from a previous run (after step 1), use Step 2-alt below
 # update the function arguments below as necessary, and run the function
+
 run_SDM(
   begin_step = "1",
   model_species = model_species, # species code in DB; new folder to create in loc_model if not existing
@@ -66,16 +61,16 @@ run_SDM(
   nm_presFile = nm_presFile,
   nm_db_file = nm_db_file, 
   loc_model = loc_model,
-  loc_envVars = "D:/SDM/Tobacco/env_vars/Tobacco",
-  nm_bkgPts = "D:/SDM/Tobacco/inputs/background/tobacco/tobacco_att.shp",
-  nm_refBoundaries = "D:/SDM/Tobacco/other_spatial/shp/StatesEast.shp", # background grey refernce lines in map
-  nm_studyAreaExtent = "D:/SDM/Tobacco/other_spatial/shp/sdmVA_pred_20170131.shp", # outline black boundary line for study area in map
-  model_comments = "testing master (terrestrial)",
-  metaData_comments = "bla bla",
-  modeller = "David Bucklin",
-  add_vars = NULL,
-  remove_vars = NULL,
-  prompt = TRUE
+  loc_envVars = loc_envVars,
+  nm_bkgPts = nm_bkgPts,
+  nm_refBoundaries = nm_refBoundaries, # background grey refernce lines in map
+  nm_studyAreaExtent = nm_studyAreaExtent, # outline black boundary line for study area in map
+  model_comments = model_comments,
+  metaData_comments = metaData_comments,
+  modeller = modeller,
+  add_vars = add_vars,
+  remove_vars = remove_vars,
+  prompt = prompt
 )
 
 #############################################################################
@@ -98,15 +93,17 @@ run_SDM(
 # Note that you can manually update the scripts, if desired. 
 # The scripts will automatically be accessed from 'loc_scripts' (if provided) 
 # or the location that was specified for the original model run. 
+library(here)
+rm(list=ls())
 
 # set project folder and species code for this run
-loc_model <- "E:/git/dnbucklin/Regional_SDM/_data/species"
-nm_db_file <- "E:/git/dnbucklin/Regional_SDM/_data/databases/sdm_tracking_dev_all.sqlite"
+model_species <- "micrmont"
+loc_model <- here("_data", "species")
 
 # set wd and load function
-loc_scripts <- "E:/git/dnbucklin/Regional_SDM/"
+loc_scripts <- here()
 setwd(loc_scripts)
-source("helper/run_SDM.R")
+source(here("helper", "run_SDM.R"))
 
 # example pick-up a model run at step 3 (new model, same presence/bkgd data)
   # if starting at step 2/3, provide an input tableCode to nm_presFile 
@@ -123,9 +120,31 @@ run_SDM(
 # example pick-up a model run at step 4c (metadata/comment update)
   # if starting at step 4 or later, must provide model run name to model_rdata
 run_SDM(
-  begin_step = "4",
+  begin_step = "4c",
   model_species = "micrmont",
   loc_model = loc_model,
-  model_rdata = "micrmont_20181015_124415",
+  model_rdata = "micrmont_20181015_150849",
   metaData_comments = "UPDATED METADATA COMMENT"
 )
+
+
+########## 
+##########
+##########
+
+# TESTING / DEBUGGING ONLY
+library(here)
+rm(list=ls())
+# Use the lines below for debugging (running line by line) for a certain script
+# This loads the variables used in previous model run for the species, 
+# so you need to have executed run_SDM in step 2 first.
+
+# for scripts 1-3, run just the following 3 lines
+model_species <- "micrmont"
+load(here("_data","species",model_species,"runSDM_paths.Rdata"))
+for(i in 1:length(fn_args)) assign(names(fn_args)[i], fn_args[[i]])
+
+# if debugging script 4 or later, also load the specific model output rdata file
+model_rdata <- max(list.files(here("_data","species",model_species,"outputs","rdata")))
+load(here("_data","species",model_species,"outputs","rdata",paste0(model_rdata)))
+


### PR DESCRIPTION
This adds `here()` to `user_run_SDM`; no more file paths! A debugging/testing section for line by line testing scripts is added to the bottom of `user_run_SDM`.

The full file structure also implemented in `_data`. 

 `loc_scripts` is fixed to your local `Regional_SDM` repository. Script archiving not implemented yet.

These changes are ready to be implemented in `terrestrial` / `aquatic` after merging here.