### PR TITLE
temporal var handling correction

### DIFF
--- a/3_createModel.R
+++ b/3_createModel.R
@@ -78,14 +78,14 @@ db <- dbConnect(SQLite(),dbname=nm_db_file)
 SQLQuery <- "select gridName, fileName from lkpEnvVars;"
 evs <- dbGetQuery(db, SQLQuery)
 # restrict to rasters in folder
-shrtNms <- merge(data.frame(fileName = raslist.short, fullname = raslist), evs)
+shrtNms <- merge(data.frame(fileName = raslist.short), evs)
 
 # get the env vars used by df.in
 # assumes all env vars in df.in are accounted for by DB and in ras folders
 shrtNms <- shrtNms[tolower(shrtNms$gridName) %in% names(df.in),]
 
 # trust that the desired env vars are in df.in
-rasnames <- shrtNms$gridName
+rasnames <- tolower(shrtNms$gridName)
 
 # get a list of all distance-to env vars
 SQLquery <- "SELECT gridName FROM lkpEnvVars WHERE distToGrid = 1;"

--- a/4_predictModelToStudyArea.R
+++ b/4_predictModelToStudyArea.R
@@ -37,6 +37,7 @@ setwd(loc_envVars)
 db <- dbConnect(SQLite(),dbname=nm_db_file)
 SQLQuery <- "select gridName, fileName from lkpEnvVars;"
 evs <- dbGetQuery(db, SQLQuery)
+evs$gridName <- tolower(evs$gridName)
 rasFiles <- merge(data.frame(gridName = stackOrder), evs)
 #sort it back to stackOrder's order
 rasFiles <- rasFiles[match(stackOrder, rasFiles$gridName),]


### PR DESCRIPTION
@tghoward This re-integrates the temporal variable handling with the latest EnvVar name handling changes. Since I still don't have mobiprep access I'm a little in the dark, so I'm wondering:

- are there any temporal variables in the raster set for MoBI?
- is the short name (gridName) now always lowercase in lkpEnvVars? 