### PR TITLE
Terrestrial - sampling in presence polygons

### DIFF
--- a/4_predictModelToStudyArea.R
+++ b/4_predictModelToStudyArea.R
@@ -94,10 +94,6 @@ if (all(c("snow","parallel") %in% installed.packages())) {
 }
 
 # delete temp rasts folder
-#if (dir.exists(paste(loc_model, model_species, "inputs", "temp_rasts", sep = "/"))) {
-#  unlink(x = paste(loc_model, model_species, "inputs", "temp_rasts", sep = "/"), recursive = T, force = T)
-#}
-# delete temp rasts folder
-if (dir.exists(paste0(options("rasterTmpDir")[1], "/", model_species))) {
-  unlink(x = paste0(options("rasterTmpDir")[1], "/", model_species), recursive = T, force = T)
+if (dir.exists(paste(loc_model, model_species, "inputs", "temp_rasts", sep = "/"))) {
+  unlink(x = paste(loc_model, model_species, "inputs", "temp_rasts", sep = "/"), recursive = T, force = T)
 }

--- a/4_predictModelToStudyArea.R
+++ b/4_predictModelToStudyArea.R
@@ -94,6 +94,10 @@ if (all(c("snow","parallel") %in% installed.packages())) {
 }
 
 # delete temp rasts folder
-if (dir.exists(paste(loc_model, model_species, "inputs", "temp_rasts", sep = "/"))) {
-  unlink(x = paste(loc_model, model_species, "inputs", "temp_rasts", sep = "/"), recursive = T, force = T)
+#if (dir.exists(paste(loc_model, model_species, "inputs", "temp_rasts", sep = "/"))) {
+#  unlink(x = paste(loc_model, model_species, "inputs", "temp_rasts", sep = "/"), recursive = T, force = T)
+#}
+# delete temp rasts folder
+if (dir.exists(paste0(options("rasterTmpDir")[1], "/", model_species))) {
+  unlink(x = paste0(options("rasterTmpDir")[1], "/", model_species), recursive = T, force = T)
 }

--- a/helper/crop_mask_rast.R
+++ b/helper/crop_mask_rast.R
@@ -24,8 +24,7 @@ hucRange <- st_zm(st_read(nm_range, query = qry))
 # crop/mask rasters to a temp directory 
 
 # delete temp rasts folder, create new
-# temp <- paste0(loc_model, "/", model_species, "/inputs/temp_rasts")
-temp <- paste0(options("rasterTmpDir")[1], "/", model_species)
+temp <- paste0(loc_model, "/", model_species, "/inputs/temp_rasts")
 if (dir.exists(temp)) {
   unlink(x = temp, recursive = T, force = T)
 }

--- a/helper/crop_mask_rast.R
+++ b/helper/crop_mask_rast.R
@@ -24,7 +24,8 @@ hucRange <- st_zm(st_read(nm_range, query = qry))
 # crop/mask rasters to a temp directory 
 
 # delete temp rasts folder, create new
-temp <- paste0(loc_model, "/", model_species, "/inputs/temp_rasts")
+# temp <- paste0(loc_model, "/", model_species, "/inputs/temp_rasts")
+temp <- paste0(options("rasterTmpDir")[1], "/", model_species)
 if (dir.exists(temp)) {
   unlink(x = temp, recursive = T, force = T)
 }


### PR DESCRIPTION
@tghoward Sorry for another PR but I had noticed today this about `st_sample`:

> When sampling polygons, the returned sampling size may differ from the requested size, as the bounding box is sampled, and sampled points intersecting the polygon are returned.

My solution here is to ask `st_sample` for 2x the number we want in the end (`finalSampNum`), and then use base `sample` to pull the actual number after the fact. 

There could still possibly be undersampling with this, but there won't be oversampling.