### PR TITLE
raster temporary files

### DIFF
--- a/4_predictModelToStudyArea.R
+++ b/4_predictModelToStudyArea.R
@@ -94,6 +94,6 @@ if (all(c("snow","parallel") %in% installed.packages())) {
 }
 
 # delete temp rasts folder
-if (dir.exists(paste0(options("rasterTmpDir")[1], "/", model_species))) {
-  unlink(x = paste0(options("rasterTmpDir")[1], "/", model_species), recursive = T, force = T)
+if (dir.exists(paste0(options("rasterTmpDir")[1], "/", modelrun_meta_data$model_run_name))) {
+  unlink(x = paste0(options("rasterTmpDir")[1], "/", modelrun_meta_data$model_run_name), recursive = T, force = T)
 }

--- a/helper/crop_mask_rast.R
+++ b/helper/crop_mask_rast.R
@@ -24,7 +24,7 @@ hucRange <- st_zm(st_read(nm_range, query = qry))
 # crop/mask rasters to a temp directory 
 
 # delete temp rasts folder, create new
-temp <- paste0(options("rasterTmpDir")[1], "/", model_species)
+temp <- paste0(options("rasterTmpDir")[1], "/", modelrun_meta_data$model_run_name)
 if (dir.exists(temp)) {
   unlink(x = temp, recursive = T, force = T)
 }
@@ -48,7 +48,7 @@ ext <- st_bbox(rng)
 # cluster process rasters
 cl <- makeCluster(parallel::detectCores() - 1, type = "SOCK") 
 clusterExport(cl, list("temp", "ext", "clipshp"), envir = environment()) 
-clusterExport(cl, list("loc_envVars")) 
+clusterExport(cl, list("loc_envVars"), envir = environment()) 
 
 message("Creating raster subsets for species for ", length(fullL) , " environmental variables...")
 newL <- parLapply(cl, x = fullL, fun = function(x) {


### PR DESCRIPTION
This makes use of the `raster` package temporary directory for writing temporary rasters. To set the the particular folder `raster` uses as a global option:

- edit the **RProfile.site** file (e.g., `C:/Program Files/R/R-3.x.x/etc/RProfile.site`), adding the lines:
```
dir.create("D:/raster", showWarnings = F)
options(rasterTmpDir="D:/raster")
```