### PR TITLE
move modelrun_meta_data to script 3

### DIFF
--- a/3_createModel.R
+++ b/3_createModel.R
@@ -11,6 +11,8 @@ library(vcd)     #for kappa stats
 library(abind)   #for collapsing the nested lists
 library(foreign) #for reading dbf files
 library(randomForest)
+source(paste0(loc_scripts, "/helper/modelrun_meta_data.R"), local = T) # generates modelrun_meta_data
+
 
 setwd(loc_model)
 dir.create(paste0(model_species,"/outputs/rdata"), recursive = T, showWarnings = F)

--- a/3_createModel.R
+++ b/3_createModel.R
@@ -579,7 +579,7 @@ tblModelResults <- data.frame(model_run_name = model_run_name, EGT_ID = ElementN
 dbWriteTable(db, "tblModelResults", tblModelResults, append = T)
 
 # tblModelResultsVarsUsed
-varImpDB <- data.frame(model_run_name = model_run_name, gridName = envvar_list, inFinalModel = 0)
+varImpDB <- data.frame(model_run_name = model_run_name, gridName = tolower(envvar_list), inFinalModel = 0)
 varImpDB <- merge(varImpDB, EnvVars[c("gridName","impVal")], by = "gridName", all.x = T)
 varImpDB$inFinalModel[!is.na(varImpDB$impVal)] <- 1
 dbWriteTable(db, "tblModelResultsVarsUsed", varImpDB, append = T)

--- a/helper/modelrun_meta_data.R
+++ b/helper/modelrun_meta_data.R
@@ -1,0 +1,22 @@
+# modelrun_meta_data
+# sources at beginning of 3rd script.
+
+repo <- git2r::repository()
+repo_head <- git2r::last_commit(repo)$sha
+rm(repo)
+model_start_time <- as.character(Sys.time())
+sdat <- Sys.info()
+model_comp_name <- sdat[['nodename']]
+r_version <- R.version.string
+model_run_name <- paste0(model_species, "_" , gsub(" ","_",gsub(c("-|:"),"",as.character(model_start_time))))
+if (modeller == "Your name") modeller <- sdat[['effective_user']]
+modelrun_meta_data <- list(model_run_name = model_run_name,
+                           model_start_time=model_start_time,
+                           modeller = modeller,
+                           model_comp_name=model_comp_name,
+                           r_version = r_version,
+                           model_comments = model_comments,
+                           repo_head = repo_head)
+# re-save fn_args with model_run
+fn_args$modelrun_meta_data <- modelrun_meta_data
+save(fn_args, file = paste0(loc_model, "/" , model_species, "/runSDM_paths.Rdata"))

--- a/helper/run_SDM.R
+++ b/helper/run_SDM.R
@@ -133,29 +133,6 @@ run_SDM <- function(
     # reload variables
     for(i in 1:length(fn_args)) assign(names(fn_args)[i], fn_args[[i]])
     
-    # modelrun_meta_data
-    if (scrpt == "3_createModel.R") {
-      repo <- git2r::repository()
-      repo_head <- git2r::last_commit(repo)$sha
-      rm(repo)
-      model_start_time <- as.character(Sys.time())
-      sdat <- Sys.info()
-      model_comp_name <- sdat[['nodename']]
-      r_version <- R.version.string
-      model_run_name <- paste0(model_species, "_" , gsub(" ","_",gsub(c("-|:"),"",as.character(model_start_time))))
-      if (modeller == "Your name") modeller <- sdat[['effective_user']]
-      modelrun_meta_data <- list(model_run_name = model_run_name,
-                                 model_start_time=model_start_time,
-                                 modeller = modeller,
-                                 model_comp_name=model_comp_name,
-                                 r_version = r_version,
-                                 model_comments = model_comments,
-                                 repo_head = repo_head)
-      # re-save fn_args with model_run
-      fn_args$modelrun_meta_data <- modelrun_meta_data
-      save(fn_args, file = paste0(loc_model, "/" , model_species, "/runSDM_paths.Rdata"))
-    }
-    
     # run script
     source(paste(loc_scripts, scrpt, sep = "/"), local = TRUE)
     


### PR DESCRIPTION
This should address issue #36 by generating `modelrun_meta_data`  object directly in script 3.

Also includes 85b921c addressing a bug which affected metadata variable description table.