### PR TITLE
model run name in metadata

### DIFF
--- a/MetadataEval_knitr.rnw
+++ b/MetadataEval_knitr.rnw
@@ -559,6 +559,7 @@ Appendix 2. Model details for reproducibility. All R Scripts are available at \h
     \setlength{\parskip}{0pt}
     \setlength{\parsep}{0pt}
   \item{The repository version (repo head) used for this run was: \Sexpr{modelrun_meta_data$repo_head}}
+  \item{The model run name was: \Sexpr{model_run_name}}
   \item{Validation metrics requiring a threshold use MTP (minimum training presence)}
   \item{R version: \Sexpr{modelrun_meta_data$r_version}}
   \item{Random seed for full randomForest model: \Sexpr{modelrun_meta_data$seed}}


### PR DESCRIPTION
@tghoward @akconley @matthewpaulking, this should be pulled into terrestrial to add the model run name in appendix 2 of the metadata.