### PR TITLE
use stars for raster to poly

### DIFF
--- a/helper/pkg_check.R
+++ b/helper/pkg_check.R
@@ -5,7 +5,7 @@ pkg_list <- c("RSQLite","rgdal","sp","rgeos","raster","maptools",
               "ROCR","vcd","abind","foreign","randomForest",
               "snow", "DBI", "knitr","RColorBrewer","rasterVis","xtable",
               "git2r","spsurvey", "here","sf","dplyr","stringi","tmap","tmaptools","OpenStreetMap",
-              "snowfall", "smoothr", "tables","rJava", "tinytex", "odbc")
+              "snowfall", "smoothr", "tables","rJava", "tinytex", "odbc", "stars")
 
 installed <- installed.packages()
 to_inst <- pkg_list[!pkg_list %in% installed[,1]]


### PR DESCRIPTION
using `raster` in packaging step is turning our to be unsustainable: sucks up RAM and very large (complex?) feature classes crash it. 

Luckily `stars` seems to fix those problems and is *much* faster. Yay!