### PR TITLE
add datatype in raster crop

### DIFF
--- a/1_pointsInPolys_cleanBkgPts.R
+++ b/1_pointsInPolys_cleanBkgPts.R
@@ -21,14 +21,14 @@ library(dplyr)
 setwd(loc_model)
 
 # set up folder system for inputs
-dir.create(paste0(model_species,"/inputs/presence"), recursive = T, showWarnings = F)
-dir.create(paste0(model_species,"/inputs/model_input"), showWarnings = F)
+dir.create(paste0(model_species,"/inputs/presence"), recursive = TRUE, showWarnings = FALSE)
+dir.create(paste0(model_species,"/inputs/model_input"), showWarnings = FALSE)
 
 # setwd(paste0(loc_model,"/",model_species,"/inputs/presence"))
 # changing to this WD temporarily allows for presence file to be either in presence folder or specified with full path name
 
 # load data, QC ----
-presPolys <- st_zm(st_read(nm_presFile, quiet = T))
+presPolys <- st_zm(st_read(nm_presFile, quiet = TRUE))
 
 #check for proper column names. If no error from next code block, then good to go
 #presPolys$RA <- presPolys$SFRACalc

--- a/helper/crop_mask_rast.R
+++ b/helper/crop_mask_rast.R
@@ -53,7 +53,7 @@ if(!exists("rangeClipped")){
 }
 
 #check if shape is valid
-if(!st_is_valid(rangeClipped)){
+if(FALSE %in% st_is_valid(rangeClipped)){
   # st_make_valid not available to this install
   rangeClipped <- st_buffer(rangeClipped, 0)
 }
@@ -108,9 +108,10 @@ newL <- snow::parLapply(cl, x = fullL, fun = function(path) {
 
   ## with fasterize and raster
   ras <- raster::raster(path) # read the raster
+  dtp <- raster::dataType(ras) # get data type, some crops are setting large values to NA
   cropRas <- raster::raster(clipRas) # read the crop raster
-  rasAtExtent <- raster::crop(ras, raster::extent(cropRas)) # crop extent to same as mask ras
-  outRas <- raster::mask(rasAtExtent, cropRas, filename = nnm, options="COMPRESS=NONE") # mask it
+  rasAtExtent <- raster::crop(ras, raster::extent(cropRas), datatype = dtp) # crop extent to same as mask ras
+  outRas <- raster::mask(rasAtExtent, cropRas, filename = nnm, options="COMPRESS=NONE", datatype = dtp) # mask it
 
   return(nnm)
 })


### PR DESCRIPTION
this could be a bug in raster package ... not specifying data type in either (not sure which) raster::crop or raster::mask results in sometimes the data type changing ... resulting cells getting flipped to NA (!)