### PR TITLE
bug: need nchar, not length

### DIFF
--- a/MetadataEval_knitr.rnw
+++ b/MetadataEval_knitr.rnw
@@ -309,7 +309,7 @@ Category & Metric & Score & Notes
 \medskip
 \noindent
 <<customComments, results="asis", echo = FALSE>>=
-if(length(sdm.customComments.subset$comments) > 1){
+if(nchar(sdm.customComments.subset$comments) > 1){
   cat("\\textbf{Model Comments} \\\\")
   cat(sdm.customComments.subset$comments)
 }


### PR DESCRIPTION
the comment wasn't getting printed on pdf. I think this is the fix. 